### PR TITLE
Feature/docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,22 @@ Watch the [demo](https://youtu.be/K7PJqIbQVjE) to see Elara in action.
 
 ## Setup
 
-### Python
+### Run with Docker
+
+To quickly set up and run Elara using Docker, follow these steps:
+
+1. Ensure you have [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed on your system.
+2. Use the following command to build and start the services:
+```bash
+docker compose up -d
+```
+3. Wait until both services are up and running:
+4. The Python API will be available at http://localhost:8000.
+5. The SvelteKit app will be available at http://localhost:5173 (check Usage for details).
+
+### Run without Docker
+
+#### Python
 
 First, if you don't have [`uv`](https://github.com/astral-sh/uv) installed on your system, install it with the following commands (`uv` allows for easy package and version management for Python projects):
 
@@ -35,7 +50,7 @@ cd python && uv run --python 3.12 --with-requirements requirements.txt main.py
 
 Wait until you see `INFO:     Application startup complete.` in the terminal before running and using the SvelteKit app (ensures that the model has been loaded and the server is ready to handle requests).
 
-### SvelteKit
+#### SvelteKit
 
 Run the SvelteKit app with `npm`:
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ To quickly set up and run Elara using Docker, follow these steps:
 docker compose up -d
 ```
 3. Wait until both services are up and running:
-4. The Python API will be available at http://localhost:8000.
-5. The SvelteKit app will be available at http://localhost:5173 (check Usage for details).
+4. The Python API will be available at `http://localhost:8000`.
+5. The SvelteKit app will be available at `http://localhost:5173` (check Usage for details).
 
 ### Run without Docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  elara-api:
+    build:
+      dockerfile: ./python/Dockerfile
+    container_name: elara-api
+    ports:
+      - "8000:8000"
+
+  elara-ui:
+    build:
+      dockerfile: ./sveltekit/Dockerfile
+    container_name: elara-ui
+    ports:
+      - "5173:5173"
+    depends_on:
+      - elara-api

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+WORKDIR /app/api
+
+# Copy requirements and install dependencies
+COPY ./python/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY ./python/ .
+
+# Copy Labels
+COPY labels.txt /app/
+
+# Expose the application port
+EXPOSE 8000
+
+# Run the application
+CMD ["python", "main.py"]

--- a/sveltekit/Dockerfile
+++ b/sveltekit/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:22-slim
+
+WORKDIR /app/ui
+
+# Copy package.json and install dependencies
+COPY ./sveltekit/package.json ./sveltekit/package-lock.json ./
+RUN npm install
+
+# Copy application code
+COPY ./sveltekit/ .
+
+# Expose the application port
+EXPOSE 5173
+
+# Run the SvelteKit application
+ENTRYPOINT ["npm", "run", "dev"]

--- a/sveltekit/vite.config.js
+++ b/sveltekit/vite.config.js
@@ -2,5 +2,9 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	server: {
+		host: "0.0.0.0",
+		port: 5173
+	}
 });


### PR DESCRIPTION
# Docker support

## Description

This PR addresses [#1](https://github.com/amanvirparhar/elara/issues/1) by introducing Docker support for running the Elara application in a simple and quick environment. The implementation is not production-ready or optimized, but it works effectively to provide an easy way to spin up the application without worrying about major dependencies or conflicts.

## Changes made

1. **Added `docker-compose.yml`**:  
   - Configures two services:
     - `elara-api`: Runs the Python API on port `8000`.
     - `elara-ui`: Runs the SvelteKit app on port `5173` and depends on the API service.
   
2. **Created Dockerfiles**:  
   - **For the Python API**:
     - Located in `python/Dockerfile`.
     - Installs dependencies and runs the API server.
   - **For the SvelteKit app**:
     - Located in `sveltekit/Dockerfile`.
     - Installs Node.js dependencies and runs the development server.

3. **Updated README**:
   - Added instructions on how to run the application using Docker.

## How to test

1. Ensure Docker and Docker Compose are installed on your system.
2. Run the following command in the project directory:
```bash
docker compose up -d
```